### PR TITLE
fix capitalized namespace attribute on rbac doc (ind)

### DIFF
--- a/content/id/docs/reference/access-authn-authz/rbac.md
+++ b/content/id/docs/reference/access-authn-authz/rbac.md
@@ -64,7 +64,7 @@ untuk memberikan akses baca pada {{< glossary_tooltip text="Pod" term_id="pod" >
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  Namespace: default
+  namespace: default
   name: pod-reader
 rules:
 - apiGroups: [""] # "" mengindikasikan grup API inti


### PR DESCRIPTION
fix capitalized namespace attribute that cause manifest failed to apply

### Changes
- [x] replace `Namespace` to `namespace` on example role manifest
